### PR TITLE
Add dependency age policy settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,10 @@ classifiers = [
 Homepage = "https://github.com/kitsuyui/python-mitmcache"
 
 [tool.uv]
+# Source of truth:
+# https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies
+# PyPI policy in this repo uses a 2 day quarantine window.
+exclude-newer = "2 days"
 dev-dependencies = [
     "pytest",
     "pytest-cov",


### PR DESCRIPTION
## Summary
- add `exclude-newer = "2 days"` under `[tool.uv]`
- add inline comments that point to the wiki page used as the source of truth

## Why
- this introduces a 2 day package age policy for uv resolution
- the rationale and official references are maintained in the shared wiki document

## Reference
- https://github.com/kitsuyui/kitsuyui/wiki/Official-Information-for-Dependency-Update-Policies

## Validation
- TOML syntax check
