### PR TITLE
Enable Ruff McCabe complexity limit

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -98,21 +98,19 @@ class Cache:
                 logger.info(f"Cache stored: {cache_key}")
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
-        # 1. Try from flow metadata
-        cache_key = flow.metadata.get(self.cache_key)
-        if cache_key is not None:
-            return str(cache_key)
-        # 2. Try from request headers
-        cache_key = flow.request.headers.get(self.cache_key)
-        if cache_key is not None:
-            return str(cache_key)
-        # 3. Try from response headers
-        if not flow.response:
-            return None
-        cache_key = flow.response.headers.get(self.cache_key)
-        if cache_key:
-            return str(cache_key)
+        for candidate in self.cache_key_candidates(flow):
+            if candidate:
+                return str(candidate)
         return None
+
+    def cache_key_candidates(self, flow: HTTPFlow) -> list[str | object | None]:
+        candidates: list[str | object | None] = [
+            flow.metadata.get(self.cache_key),
+            flow.request.headers.get(self.cache_key),
+        ]
+        if flow.response:
+            candidates.append(flow.response.headers.get(self.cache_key))
+        return candidates
 
     def done(self) -> None:
         self.storage.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,10 @@ build-backend = "setuptools.build_meta"
 line-length = 79
 
 [tool.ruff.lint]
-extend-select = ["UP"]
+extend-select = ["UP", "C90"]
+
+[tool.ruff.lint.mccabe]
+max-complexity = 5
 
 [tool.poe.tasks.proxy]
 cmd = "mitmdump -s inject.py --set cache_file=${cache_file}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ line-length = 79
 extend-select = ["UP", "C90"]
 
 [tool.ruff.lint.mccabe]
-max-complexity = 5
+max-complexity = 4
 
 [tool.poe.tasks.proxy]
 cmd = "mitmdump -s inject.py --set cache_file=${cache_file}"


### PR DESCRIPTION
## Summary
- enable Ruff `C90`
- add Ruff McCabe `max-complexity = 5`
- lower the limit to `4`
- simplify cache key lookup by iterating over ordered candidates

## Testing
- `uv run poe check`
- `uv run poe test`