### PR TITLE
Store SQLite cache metadata in schema order

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -53,8 +53,8 @@ class SQLiteStorage:
             sql,
             (
                 cache_key,
-                request.method,
                 request.url,
+                request.method,
                 f.getvalue(),
             ),
         )
@@ -75,8 +75,8 @@ class SQLiteStorage:
         cursor.execute(
             sql,
             (
-                request.method,
                 request.url,
+                request.method,
                 f.getvalue(),
                 cache_key,
             ),

--- a/tests/storage/test_sqlite3.py
+++ b/tests/storage/test_sqlite3.py
@@ -18,3 +18,31 @@ def test_cache_storage() -> None:
     storage.purge("test")
     assert storage.get("test") is None
     storage.close()
+
+
+def test_cache_storage_keeps_request_metadata_order() -> None:
+    """Confirm that URL and method are stored in their schema columns."""
+    storage = SQLiteStorage(":memory:")
+    flow = example_flow()
+    storage.store("test", flow)
+
+    row = storage.conn.execute(
+        "SELECT url, method FROM cache WHERE cache_key=?",
+        ("test",),
+    ).fetchone()
+    assert row is not None
+    assert row["url"] == flow.request.url
+    assert row["method"] == flow.request.method
+
+    flow.request.method = "POST"
+    flow.request.url = "https://example.com/updated"
+    storage.update("test", flow)
+
+    row = storage.conn.execute(
+        "SELECT url, method FROM cache WHERE cache_key=?",
+        ("test",),
+    ).fetchone()
+    assert row is not None
+    assert row["url"] == flow.request.url
+    assert row["method"] == flow.request.method
+    storage.close()


### PR DESCRIPTION
## Summary

Store SQLite cache request metadata in the same order as the cache table schema.

## Details

- Write `url` and `method` values into their matching SQLite columns for both insert and update paths.
- Add a regression test that reads the raw cache row after `store` and `update` to verify the metadata columns.

## Verification

- `uv sync`
- `uv run poe test tests/storage/test_sqlite3.py`
- `uv run poe check mitmcache/storage/sqlite3.py tests/storage/test_sqlite3.py`
- `uv run ruff format --check mitmcache/storage/sqlite3.py tests/storage/test_sqlite3.py`
- `git diff --check`

Note: `uv run mypy mitmcache tests` currently stops in `.venv` while parsing mitmproxy dependency code (`mitmproxy/net/dns/https_records.py`). The changed files are covered by the targeted pytest and ruff checks above.
