### PR TITLE
Preserve cache hit origin state

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -59,6 +59,8 @@ class Cache:
         cache_key = self.get_cache_key_from_flow(flow)
         search_cache = True if cache_key is not None else False
 
+        cache_from_origin = True
+
         # Get response from cache
         if search_cache and cache_key:
             cache = self.storage.get(cache_key)
@@ -68,7 +70,7 @@ class Cache:
                 flow.response = cache.response
                 flow.response.headers[self.cache_key] = cache_key
                 flow.metadata[self.cache_key] = cache_key
-                flow.metadata[self.cache_from_origin] = False
+                cache_from_origin = False
         else:
             cache_key = generate_cache_key_by_uuid()
             # Remove header before sending to origin server
@@ -76,7 +78,7 @@ class Cache:
 
         # Set cache key to flow
         flow.metadata[self.cache_key] = cache_key
-        flow.metadata[self.cache_from_origin] = True
+        flow.metadata[self.cache_from_origin] = cache_from_origin
 
     def response(self, flow: http.HTTPFlow) -> None:
         """response
@@ -103,7 +105,9 @@ class Cache:
                 return str(candidate)
         return None
 
-    def cache_key_candidates(self, flow: HTTPFlow) -> list[str | object | None]:
+    def cache_key_candidates(
+        self, flow: HTTPFlow
+    ) -> list[str | object | None]:
         candidates: list[str | object | None] = [
             flow.metadata.get(self.cache_key),
             flow.request.headers.get(self.cache_key),

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,7 +3,33 @@ from __future__ import annotations
 from mitmproxy.addons import script
 from mitmproxy.test import taddons, tflow, tutils
 
+from mitmcache.storage.cache_storage import CacheStorage
+
 from .example_flow import example_flow
+
+
+class TrackingStorage:
+    def __init__(self, storage: CacheStorage) -> None:
+        self.storage = storage
+        self.store_count = 0
+        self.update_count = 0
+
+    def get(self, cache_key):
+        return self.storage.get(cache_key)
+
+    def store(self, cache_key, flow):
+        self.store_count += 1
+        self.storage.store(cache_key, flow)
+
+    def update(self, cache_key, flow):
+        self.update_count += 1
+        self.storage.update(cache_key, flow)
+
+    def purge(self, cache_key):
+        self.storage.purge(cache_key)
+
+    def close(self):
+        self.storage.close()
 
 
 def test_load_addon() -> None:
@@ -37,6 +63,8 @@ def test_cache_hit() -> None:
     """
     with taddons.context() as tctx:
         addon = tctx.script("inject.py").addons[0]
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
 
         flow = tflow.tflow(
             req=tutils.treq(
@@ -53,6 +81,8 @@ def test_cache_hit() -> None:
         # cache miss but the response is stored
         addon.request(flow)
         addon.response(flow)
+        assert storage.store_count == 1
+        assert storage.update_count == 0
 
         flow = tflow.tflow(
             req=tutils.treq(
@@ -68,7 +98,10 @@ def test_cache_hit() -> None:
         assert flow.response is not None
         assert flow.response.status_code == 200
         assert flow.response.text == "Hello, World!"
+        assert flow.metadata[addon.cache_from_origin] is False
         addon.response(flow)
+        assert storage.store_count == 1
+        assert storage.update_count == 0
         addon.done()
 
 


### PR DESCRIPTION
## Summary

- Keep `cache_from_origin` false when a request is served from cache.
- Add regression coverage that cache-hit response handling does not call storage `store` or `update`.

## Testing

- `uv run ruff format --check mitmcache tests`
- `uv run poe check`
- `uv run poe test`
- `uv run mypy --python-version 3.13 mitmcache tests`