### PR TITLE
Use reusable maintenance workflows

### DIFF
--- a/.github/workflows/happy.yml
+++ b/.github/workflows/happy.yml
@@ -9,10 +9,4 @@ permissions:
 
 jobs:
   happy:
-    runs-on: ubuntu-latest
-    name: happy
-    continue-on-error: true
-    steps:
-      - uses: kitsuyui/happy-commit@v0.8
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/happy-commit.yml@main


### PR DESCRIPTION
## Summary
- Replace direct maintenance action invocations with reusable workflows from `kitsuyui/gh-actions-workflows`.
- Keep repository-specific triggers and permissions in the caller workflows.
- Split embedded spellcheck steps into a reusable spellcheck job where needed.

## Verification
- Parsed the changed workflow YAML files.
- Ran `actionlint` on the changed workflow files.
