### PR TITLE
Close previous storage on reconfigure

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -35,6 +35,11 @@ class Cache:
         self.storage_factory.load(loader)
 
     def configure(self, updated: set[str]) -> None:
+        existing = getattr(self, "storage", None)
+        if existing is not None and "cache_file" not in updated:
+            return
+        if existing is not None:
+            existing.close()
         self.storage = self.storage_factory.create()
 
     @property

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -105,6 +105,36 @@ def test_cache_hit() -> None:
         addon.done()
 
 
+def test_configure_closes_previous_storage() -> None:
+    """Confirm that reconfiguring closes the previous storage."""
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        previous = TrackingStorage(addon.storage)
+        addon.storage = previous
+        previous.close_count = 0
+
+        original_close = previous.close
+
+        def tracked_close() -> None:
+            previous.close_count += 1
+            original_close()
+
+        previous.close = tracked_close  # type: ignore[method-assign]
+
+        # Re-applying configure with cache_file in the updated set should
+        # close the previous storage and create a fresh one.
+        addon.configure({"cache_file"})
+        assert previous.close_count == 1
+        assert addon.storage is not previous
+
+        # configure with an unrelated option should not recreate storage.
+        current = addon.storage
+        addon.configure({"cache_key"})
+        assert addon.storage is current
+
+        addon.done()
+
+
 def test_get_cache_key_from_flow() -> None:
     """Confirm that the cache key is extracted from the flow."""
     with taddons.context() as tctx:


### PR DESCRIPTION
## Summary

`Cache.configure(updated)` rebuilt `self.storage` on every mitmproxy option change without closing the prior instance. Effects:

- The in-memory SQLite cache (`cache_file=":memory:"`) was silently dropped whenever any option (e.g. `cache_key`) changed during a session.
- With `cache_file` pointed at a real file, the previous SQLite connection / file lock was never released because `Cache.configure` never called `SQLiteStorage.close()`. The `CacheStorage` Protocol already declares `close()` as part of the contract.

## Change

- Short-circuit `configure(updated)` when `cache_file` is not in `updated` and a storage already exists, so unrelated option changes leave the cache intact.
- Close the existing storage (when present) before creating a new one, so file / connection resources are released deterministically.

## Test plan

- [x] `uv run poe test` (7 passed)
- [x] `uv run poe check` (ruff)
- [x] `uv run poe format` (no changes)
- [x] New `test_configure_closes_previous_storage` asserts that re-configuring with `cache_file` calls `close()` on the previous storage and that an unrelated option update keeps the same instance.