### PR TITLE
Strip Mitm-Cache-Key header before forwarding to origin

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -62,6 +62,10 @@ class Cache:
         """
         # Get cache key or create it from request headers
         cache_key = self.get_cache_key_from_flow(flow)
+        # Cache key header is a proxy-internal hint; never forward it to the
+        # origin regardless of cache hit / miss / no-key. Pop once here so
+        # all branches stay symmetric and a future branch cannot leak it.
+        flow.request.headers.pop(self.cache_key, None)
         search_cache = True if cache_key is not None else False
 
         cache_from_origin = True
@@ -78,8 +82,6 @@ class Cache:
                 cache_from_origin = False
         else:
             cache_key = generate_cache_key_by_uuid()
-            # Remove header before sending to origin server
-            flow.request.headers.pop(self.cache_key, None)
 
         # Set cache key to flow
         flow.metadata[self.cache_key] = cache_key

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -135,6 +135,48 @@ def test_configure_closes_previous_storage() -> None:
         addon.done()
 
 
+def test_cache_key_header_stripped_before_origin() -> None:
+    """`Mitm-Cache-Key` request header must not leak to the origin server.
+
+    Covers cache miss (storage returns None) and the no-cache-key path. The
+    cache hit case is already exercised by `test_cache_hit`; the request is
+    short-circuited there so no origin call happens regardless.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+
+        # case1. cache key supplied but cache miss -> request is forwarded
+        # to origin, header must be stripped first.
+        flow_miss = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"miss-key")],
+            ),
+            resp=False,
+        )
+        addon.request(flow_miss)
+        assert flow_miss.response is None
+        assert addon.cache_key not in flow_miss.request.headers
+        assert flow_miss.metadata[addon.cache_key] == "miss-key"
+
+        # case2. no cache key -> auto-uuid path, header should be absent
+        # before forwarding to origin.
+        flow_nokey = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+            ),
+            resp=False,
+        )
+        addon.request(flow_nokey)
+        assert addon.cache_key not in flow_nokey.request.headers
+
+        addon.done()
+
+
 def test_get_cache_key_from_flow() -> None:
     """Confirm that the cache key is extracted from the flow."""
     with taddons.context() as tctx:


### PR DESCRIPTION
## Summary
- Move `flow.request.headers.pop(self.cache_key, None)` to the top of `Cache.request`, right after `get_cache_key_from_flow`, so it runs on every branch (cache hit / cache miss / no cache key).
- Previously the pop only ran on the auto-uuid (no-cache-key) branch. When a caller passed `Mitm-Cache-Key` and the cache missed, the proxy-internal header was forwarded to the origin server.
- Add `test_cache_key_header_stripped_before_origin` covering the cache miss path (regression for the actual leak) and the no-cache-key path.

## Why
The cache key header is a proxy-internal hint. Forwarding it to the origin can show up in upstream logs, routing, or `Vary` calculations. The previous structure handled the symptom in only one branch, so the same leak would re-appear if a future branch gets added. Popping once after extraction makes the "never forward to origin" invariant explicit and keeps all branches symmetric.

## Test plan
- [x] `uv run poe format`
- [x] `uv run poe check`
- [x] `uv run poe test` (8/8 passed on Python 3.13, including the new regression test)
- [ ] CI matrix (3.10 / 3.11 / 3.12 / 3.13 / 3.14)