### PR TITLE
Pin workflow action refs to 40-character commit SHAs

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   actionlint:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -23,16 +23,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python
         id: setup-python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "${{ matrix.python }}"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -5,4 +5,4 @@ permissions:
   contents: read
 jobs:
   check:
-    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main
+    uses: kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@9108d679c02a52824376afcf071715fdaaa2a4e4 # main


### PR DESCRIPTION
## Summary

Pin the five external `uses:` references flagged by the supply-chain audit to 40-character commit SHAs:

| File | Before | After |
| --- | --- | --- |
| `python-test.yml:16` | `kitsuyui/gh-actions-workflows/.github/workflows/actionlint.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |
| `python-test.yml:26` | `actions/checkout@v6` | `actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6` |
| `python-test.yml:30` | `actions/setup-python@v6` | `actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6` |
| `python-test.yml:35` | `astral-sh/setup-uv@v5` | `astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5` |
| `spellcheck.yml:8` | `kitsuyui/gh-actions-workflows/.github/workflows/spellcheck.yml@main` | `@9108d679c02a52824376afcf071715fdaaa2a4e4 # main` |

The `astral-sh/setup-uv@v5` SHA matches the value already in use by `octocov.yml` in this same repository. The other SHAs match values already adopted across other kitsuyui org repos. Behavior is therefore unchanged.

`python-test.yml` and `octocov.yml` use different major version specifiers (`@v6` vs `@v4`/`@v5`); reconciling those is out of scope for this finding's evidence.

Renovate already extends `helpers:pinGitHubActionDigests` via `local>kitsuyui/renovate-config`, so future digest updates continue through automated PRs.

## Test plan

- [x] `git diff` confirms only the five `uses:` lines change
- [x] `astral-sh/setup-uv@v5` SHA matches existing pinned reference in `octocov.yml`