### PR TITLE
Replace sleep with poll loop and add EXIT trap in download_cert

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,9 +66,13 @@ args = [{ name = "cache-file", default = "cache.db" }]
 shell = """
 mitmdump &
 PID=$!
-sleep 3
-curl -x 127.0.0.1:8080 'http://mitm.it/cert/pem' -o ${cert_path}
-kill $PID
+trap 'kill $PID 2>/dev/null' EXIT
+for i in $(seq 1 30); do
+    curl -s -x 127.0.0.1:8080 'http://mitm.it/cert/pem' -o ${cert_path} && exit 0
+    sleep 1
+done
+echo "Error: mitmproxy did not become ready within 30 seconds" >&2
+exit 1
 """
 args = [{ name = "cert-path", default = "/tmp/mitm.pem" }]
 


### PR DESCRIPTION
## Summary

Fix `poe download_cert` to reliably wait for mitmproxy readiness and clean up on exit.

- Replace the fixed `sleep 3` delay with a poll-and-retry loop (up to 30 s, 1 s interval)
- Add `trap 'kill $PID 2>/dev/null' EXIT` so mitmproxy is stopped on normal exit, error, or Ctrl+C

## Changes

**Before:**
```sh
mitmdump &
PID=$!
sleep 3
curl -x 127.0.0.1:8080 'http://mitm.it/cert/pem' -o ${cert_path}
kill $PID
```

**After:**
```sh
mitmdump &
PID=$!
trap 'kill $PID 2>/dev/null' EXIT
for i in $(seq 1 30); do
    curl -s -x 127.0.0.1:8080 'http://mitm.it/cert/pem' -o ${cert_path} && exit 0
    sleep 1
done
echo "Error: mitmproxy did not become ready within 30 seconds" >&2
exit 1
```

## Trade-offs

The poll loop waits up to 30 s rather than a fixed 3 s, which is slower in the failure case but avoids silent failures on slow machines. The `EXIT` trap ensures the background mitmproxy process is always terminated, even on `Ctrl+C`.
