### PR TITLE
Replace check-then-act with atomic upsert in SQLite cache storage

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -110,13 +110,8 @@ class Cache:
         # Check if the response has a cache key
         cache_key = self.get_cache_key_from_flow(flow)
         if flow.metadata.get(self.cache_from_origin, False) and cache_key:
-            cache = self.storage.get(cache_key)
-            if cache is not None:
-                self.storage.update(cache_key, flow)
-                logger.info(f"Cache updated: {_sanitize_for_log(cache_key)}")
-            else:
-                self.storage.store(cache_key, flow)
-                logger.info(f"Cache stored: {_sanitize_for_log(cache_key)}")
+            self.storage.upsert(cache_key, flow)
+            logger.info(f"Cache stored: {_sanitize_for_log(cache_key)}")
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
         for candidate in self.cache_key_candidates(flow):

--- a/mitmcache/storage/cache_storage.py
+++ b/mitmcache/storage/cache_storage.py
@@ -18,5 +18,8 @@ class CacheStorage(Protocol):
     def update(self, cache_key: str, flow: http.HTTPFlow) -> None:
         """Update flow in cache with specified cache key."""
 
+    def upsert(self, cache_key: str, flow: http.HTTPFlow) -> None:
+        """Insert or replace flow in cache atomically."""
+
     def close(self) -> None:
         """Close cache storage."""

--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -93,6 +93,31 @@ class SQLiteStorage:
             logger.warning("update() noop: cache_key %r not found", cache_key)
         self.conn.commit()
 
+    def upsert(self, cache_key: str, flow: http.HTTPFlow) -> None:
+        request = flow.request
+        cursor = self.conn.cursor()
+        f = io.BytesIO()
+        w = mio.FlowWriter(f)
+        w.add(flow)
+        sql = """\
+        INSERT OR REPLACE INTO cache
+                  ( cache_key
+                  , url
+                  , method
+                  , flow
+                  )
+             VALUES (?, ?, ?, ?)"""
+        cursor.execute(
+            sql,
+            (
+                cache_key,
+                request.url,
+                request.method,
+                f.getvalue(),
+            ),
+        )
+        self.conn.commit()
+
     def purge(self, cache_key: str) -> None:
         cursor = self.conn.cursor()
         cursor.execute("DELETE FROM cache WHERE cache_key=?", (cache_key,))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -14,6 +14,7 @@ class TrackingStorage:
         self.storage = storage
         self.store_count = 0
         self.update_count = 0
+        self.upsert_count = 0
 
     def get(self, cache_key):
         return self.storage.get(cache_key)
@@ -25,6 +26,10 @@ class TrackingStorage:
     def update(self, cache_key, flow):
         self.update_count += 1
         self.storage.update(cache_key, flow)
+
+    def upsert(self, cache_key, flow):
+        self.upsert_count += 1
+        self.storage.upsert(cache_key, flow)
 
     def purge(self, cache_key):
         self.storage.purge(cache_key)
@@ -82,8 +87,7 @@ def test_cache_hit() -> None:
         # cache miss but the response is stored
         addon.request(flow)
         addon.response(flow)
-        assert storage.store_count == 1
-        assert storage.update_count == 0
+        assert storage.upsert_count == 1
 
         flow = tflow.tflow(
             req=tutils.treq(
@@ -101,8 +105,7 @@ def test_cache_hit() -> None:
         assert flow.response.text == "Hello, World!"
         assert flow.metadata[addon.cache_from_origin] is False
         addon.response(flow)
-        assert storage.store_count == 1
-        assert storage.update_count == 0
+        assert storage.upsert_count == 1
         addon.done()
 
 


### PR DESCRIPTION
## Summary

Replace the non-atomic check-then-act sequence in `Cache.response()` with a single
atomic `upsert()` call backed by SQLite's `INSERT OR REPLACE`.

Previously, `response()` called `storage.get()` to decide whether to call
`store()` (INSERT) or `update()` (UPDATE). If two flows carried the same cache key
and both reached `response()` concurrently after a cache miss, the second
`store()` would raise `sqlite3.IntegrityError: UNIQUE constraint failed: cache.cache_key`,
silently dropping the response from the cache.

## Changes

- `CacheStorage` protocol: adds `upsert(cache_key, flow)` method
- `SQLiteStorage`: implements `upsert()` using `INSERT OR REPLACE INTO cache`,
  which is a single atomic statement in SQLite
- `Cache.response()`: replaced three-branch get/store/update logic with a direct
  `upsert()` call, eliminating the TOCTOU window
- `tests/test_cache.py`: `TrackingStorage` gains `upsert()` and `upsert_count`;
  assertions in `test_cache_hit` updated accordingly

## Verification

- All 8 tests pass (`uv run poe test`)
- Lint clean (`uv run poe check`)
- Format unchanged (`uv run poe format`)

## Trade-offs

`INSERT OR REPLACE` deletes the existing row before inserting a new one (SQLite
semantics), which resets the auto-increment `id`. This has no observable impact
here because `id` is an internal primary key not exposed to callers. The previous
`update()` path also had no user-visible semantic difference from replace.
