### PR TITLE
Replace cached response assert with runtime guard

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -72,13 +72,7 @@ class Cache:
 
         # Get response from cache
         if search_cache and cache_key:
-            cache = self.storage.get(cache_key)
-            if cache is not None:
-                assert cache.response is not None
-                logger.info(f"Cache hit: {cache_key}")
-                flow.response = cache.response
-                flow.response.headers[self.cache_key] = cache_key
-                flow.metadata[self.cache_key] = cache_key
+            if self._set_cached_response(flow, cache_key):
                 cache_from_origin = False
         else:
             cache_key = generate_cache_key_by_uuid()
@@ -105,6 +99,23 @@ class Cache:
             else:
                 self.storage.store(cache_key, flow)
                 logger.info(f"Cache stored: {cache_key}")
+
+    def _set_cached_response(self, flow: HTTPFlow, cache_key: str) -> bool:
+        cache = self.storage.get(cache_key)
+        if cache is None:
+            return False
+        if cache.response is None:
+            logger.warning(
+                "Ignoring cached flow without response: %s", cache_key
+            )
+            self.storage.purge(cache_key)
+            return False
+
+        logger.info(f"Cache hit: {cache_key}")
+        flow.response = cache.response
+        flow.response.headers[self.cache_key] = cache_key
+        flow.metadata[self.cache_key] = cache_key
+        return True
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
         for candidate in self.cache_key_candidates(flow):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -13,6 +13,7 @@ class TrackingStorage:
         self.storage = storage
         self.store_count = 0
         self.update_count = 0
+        self.purge_count = 0
 
     def get(self, cache_key):
         return self.storage.get(cache_key)
@@ -26,6 +27,7 @@ class TrackingStorage:
         self.storage.update(cache_key, flow)
 
     def purge(self, cache_key):
+        self.purge_count += 1
         self.storage.purge(cache_key)
 
     def close(self):
@@ -102,6 +104,44 @@ def test_cache_hit() -> None:
         addon.response(flow)
         assert storage.store_count == 1
         assert storage.update_count == 0
+        addon.done()
+
+
+def test_cache_entry_without_response_is_ignored() -> None:
+    """Confirm that an incomplete cached flow does not short-circuit."""
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
+
+        cached_flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+            ),
+            resp=False,
+        )
+        storage.store("empty-response", cached_flow)
+        assert storage.store_count == 1
+
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"empty-response")],
+            ),
+            resp=False,
+        )
+
+        addon.request(flow)
+
+        assert flow.response is None
+        assert addon.cache_key not in flow.request.headers
+        assert flow.metadata[addon.cache_key] == "empty-response"
+        assert flow.metadata[addon.cache_from_origin] is True
+        assert storage.purge_count == 1
         addon.done()
 
 


### PR DESCRIPTION
## Summary
- Replace the cached-response `assert` in `Cache.request()` with an explicit runtime guard.
- Treat cached flows without a response as cache misses by logging, purging the invalid cache entry, and continuing to the origin.
- Add a regression test that covers the response-less cache entry path, including execution under `python -O`.

## Validation
- actionlint .github/workflows/*.yml
- uv run poe check
- uv run ruff format --check mitmcache tests
- uv run poe test
- uv run poe coverage-xml
- uv run python -O -m pytest tests/test_cache.py::test_cache_entry_without_response_is_ignored
- implement-validator: overall: pass

## Notes
- `uv run mypy` is not a CI gate in this repository and currently reports pre-existing test typing issues unrelated to this change.
