### PR TITLE
Add workflow concurrency controls

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   pull-requests: write

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,6 +8,10 @@ on:
     branches:
       - main
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
 


### PR DESCRIPTION
## Summary

Add top-level `concurrency` to `python-test.yml` and `octocov.yml` to cancel stale CI runs on the same branch/PR when a new push arrives.

## Verification

```
actionlint -shellcheck="" .github/workflows/octocov.yml .github/workflows/python-test.yml
# no output (all clear)
```

## Trade-offs

`cancel-in-progress: true` means any in-progress run on the same ref is cancelled when a new commit is pushed. This is the intended behaviour for PR iteration; push-to-main runs use a different ref so they are not affected by PR pushes.