### PR TITLE
Skip caching error responses (4xx/5xx) in response()

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -109,14 +109,22 @@ class Cache:
             return
         # Check if the response has a cache key
         cache_key = self.get_cache_key_from_flow(flow)
-        if flow.metadata.get(self.cache_from_origin, False) and cache_key:
-            cache = self.storage.get(cache_key)
-            if cache is not None:
-                self.storage.update(cache_key, flow)
-                logger.info(f"Cache updated: {_sanitize_for_log(cache_key)}")
-            else:
-                self.storage.store(cache_key, flow)
-                logger.info(f"Cache stored: {_sanitize_for_log(cache_key)}")
+        if not (flow.metadata.get(self.cache_from_origin, False) and cache_key):
+            return
+        # Do not cache error responses; a cached 4xx/5xx would be served
+        # indefinitely even after the origin recovers.
+        if flow.response is None or flow.response.status_code >= 400:
+            return
+        self._store_or_update(cache_key, flow)
+
+    def _store_or_update(self, cache_key: str, flow: http.HTTPFlow) -> None:
+        cache = self.storage.get(cache_key)
+        if cache is not None:
+            self.storage.update(cache_key, flow)
+            logger.info(f"Cache updated: {_sanitize_for_log(cache_key)}")
+        else:
+            self.storage.store(cache_key, flow)
+            logger.info(f"Cache stored: {_sanitize_for_log(cache_key)}")
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
         for candidate in self.cache_key_candidates(flow):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -217,6 +217,38 @@ def test_request_and_response_after_done_are_no_ops() -> None:
         assert addon._closed is False
 
 
+def test_error_response_not_cached() -> None:
+    """Error responses (4xx/5xx) must not be stored in the cache.
+
+    Caching an error response would cause the cache to serve the error
+    indefinitely even after the origin recovers.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
+
+        for status_code in (400, 401, 403, 404, 500, 502, 503):
+            flow = tflow.tflow(
+                req=tutils.treq(
+                    method=b"GET",
+                    path=b"/",
+                    host=b"localhost:65535",
+                    headers=[(b"Mitm-Cache-Key", b"err-key")],
+                ),
+                resp=tutils.tresp(
+                    content=b"Error",
+                    status_code=status_code,
+                ),
+            )
+            addon.request(flow)
+            addon.response(flow)
+
+        assert storage.store_count == 0
+        assert storage.update_count == 0
+        addon.done()
+
+
 def test_get_cache_key_from_flow() -> None:
     """Confirm that the cache key is extracted from the flow."""
     with taddons.context() as tctx:


### PR DESCRIPTION
## Summary

The `response()` method in `Cache` stored all origin responses unconditionally,
including 4xx and 5xx error responses. Once an error was cached under a key,
all subsequent requests with the same key would receive the cached error even
after the origin recovered. The only way to clear the poisoned entry was a
manual cache purge or proxy restart.

## Change

Add an early return in `response()` when the response is absent or has a
status code ≥ 400. The `storage.store()` / `storage.update()` paths are now
only reached for successful responses.

```python
if flow.response is None or flow.response.status_code >= 400:
    return
```

## Tests

Added `test_error_response_not_cached` covering the seven most common error
codes (400, 401, 403, 404, 500, 502, 503). The test verifies that
`storage.store_count` and `storage.update_count` remain zero after
processing each error response through `request()` + `response()`.

## Verification

```
$ uv run pytest tests/ -v
9 passed in 0.47s
```

## Trade-offs

- 4xx responses that should arguably be cached (e.g. 404 for stable
  "not found" resources) are now never cached. A future enhancement
  could expose a configurable `cacheable_status_codes` option, but
  that is out of scope for this correctness fix.
