### PR TITLE
Guard done() against AttributeError when called before configure()

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -124,7 +124,9 @@ class Cache:
         return candidates
 
     def done(self) -> None:
-        self.storage.close()
+        storage = getattr(self, "storage", None)
+        if storage is not None:
+            storage.close()
 
 
 def generate_cache_key_by_uuid() -> str:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from mitmproxy.addons import script
 from mitmproxy.test import taddons, tflow, tutils
 
+from mitmcache.cache import Cache
 from mitmcache.storage.cache_storage import CacheStorage
 
 from .example_flow import example_flow
@@ -30,6 +31,17 @@ class TrackingStorage:
 
     def close(self):
         self.storage.close()
+
+
+def test_done_before_configure_no_error() -> None:
+    """done() must not raise AttributeError when called before configure().
+
+    mitmproxy may call done() on early teardown before configure() ever runs.
+    Without a guard, self.storage is unset and the unconditional
+    self.storage.close() raises AttributeError.
+    """
+    addon = Cache()
+    addon.done()  # must not raise
 
 
 def test_load_addon() -> None:


### PR DESCRIPTION
## Summary

`Cache.done()` called `self.storage.close()` unconditionally, but `self.storage`
is only assigned in `configure()`. mitmproxy may call `done()` before `configure()`
completes — for example on early addon teardown when a startup configuration error
occurs. In that case `self.storage` is unset and the call raises:

```
AttributeError: 'Cache' object has no attribute 'storage'
```

This makes the root cause of the original configuration error harder to diagnose.

## Change

Replace the direct attribute access in `done()` with a `getattr` guard:

```python
def done(self) -> None:
    storage = getattr(self, "storage", None)
    if storage is not None:
        storage.close()
```

No behaviour change when `configure()` has run normally.

## Tests

Added `test_done_before_configure_no_error` which instantiates a bare `Cache`
and calls `done()` directly, confirming no `AttributeError` is raised.

## Verification

```
$ uv run pytest tests/ -v
9 passed in 0.43s
```
