### PR TITLE
Catch storage exceptions in request() and response() to keep flows alive

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -72,7 +72,14 @@ class Cache:
 
         # Get response from cache
         if search_cache and cache_key:
-            cache = self.storage.get(cache_key)
+            try:
+                cache = self.storage.get(cache_key)
+            except Exception:
+                logger.exception(
+                    "Cache storage read failed for key %s; bypassing cache",
+                    cache_key,
+                )
+                cache = None
             if cache is not None:
                 assert cache.response is not None
                 logger.info(f"Cache hit: {cache_key}")
@@ -98,13 +105,19 @@ class Cache:
         # Check if the response has a cache key
         cache_key = self.get_cache_key_from_flow(flow)
         if flow.metadata.get(self.cache_from_origin, False) and cache_key:
-            cache = self.storage.get(cache_key)
-            if cache is not None:
-                self.storage.update(cache_key, flow)
-                logger.info(f"Cache updated: {cache_key}")
-            else:
-                self.storage.store(cache_key, flow)
-                logger.info(f"Cache stored: {cache_key}")
+            try:
+                cache = self.storage.get(cache_key)
+                if cache is not None:
+                    self.storage.update(cache_key, flow)
+                    logger.info(f"Cache updated: {cache_key}")
+                else:
+                    self.storage.store(cache_key, flow)
+                    logger.info(f"Cache stored: {cache_key}")
+            except Exception:
+                logger.exception(
+                    "Cache storage write failed for key %s; response not cached",
+                    cache_key,
+                )
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
         for candidate in self.cache_key_candidates(flow):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -32,6 +32,25 @@ class TrackingStorage:
         self.storage.close()
 
 
+class FailingStorage:
+    """Storage stub that always raises on read or write operations."""
+
+    def get(self, cache_key):
+        raise OSError("simulated storage failure")
+
+    def store(self, cache_key, flow):
+        raise OSError("simulated storage failure")
+
+    def update(self, cache_key, flow):
+        raise OSError("simulated storage failure")
+
+    def purge(self, cache_key):
+        raise OSError("simulated storage failure")
+
+    def close(self):
+        pass
+
+
 def test_load_addon() -> None:
     """Confirm that the addon can be loaded."""
     script.load_script("inject.py")
@@ -235,3 +254,50 @@ def test_get_cache_key_from_flow() -> None:
         assert addon.get_cache_key_from_flow(flow) is None
 
         addon.done()
+
+
+def test_storage_exception_in_request_does_not_propagate() -> None:
+    """request() must not raise when the storage backend throws.
+
+    A storage failure (e.g. database locked, disk full) is best-effort:
+    the flow should continue and reach the origin rather than being aborted.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        addon.storage = FailingStorage()
+
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"fail-key")],
+            ),
+            resp=False,
+        )
+        addon.request(flow)  # must not raise
+        assert flow.response is None  # flow continues to origin
+
+
+def test_storage_exception_in_response_does_not_propagate() -> None:
+    """response() must not raise when the storage backend throws.
+
+    A write failure during caching is best-effort: the flow completes
+    normally even though the response is not cached.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        addon.storage = FailingStorage()
+
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"fail-key")],
+            ),
+            resp=tutils.tresp(content=b"Hello", status_code=200),
+        )
+        # Simulate that this response came from origin (cache_from_origin=True)
+        flow.metadata["Mitm-Cache-From-Origin"] = True
+        addon.response(flow)  # must not raise


### PR DESCRIPTION
## Summary

`Cache.request()` and `Cache.response()` call storage methods (`get()`,
`store()`, `update()`) without any exception handling. SQLite storage can raise:

- `sqlite3.OperationalError` — database locked by another process
- `sqlite3.DatabaseError` — corrupted database file
- `sqlite3.ProgrammingError` — operation on a closed connection
- `OSError` — disk full during `store()`

These exceptions previously propagated uncaught into the mitmproxy addon hook
layer, potentially aborting every active proxy flow whenever the cache backend
is temporarily unavailable.

## Changes

- `request()`: wraps `storage.get()` in `try/except Exception`; on error the
  flow continues to origin as a cache miss (best-effort caching).
- `response()`: wraps the entire `get → update/store` block in
  `try/except Exception`; on error the response is served normally but not
  cached.
- Both paths log the exception at ERROR level via `logger.exception()` for
  observability without raising.
- Added `FailingStorage` stub and two new tests confirming that neither
  `request()` nor `response()` raises when the storage backend raises `OSError`.

## Verification

```
uv run poe format   # 1 file reformatted
uv run poe check    # all checks passed
uv run poe test     # 10 passed
```

Static analysis: `ruff check` (0 additional findings on new code).

## Trade-offs

- `except Exception` is broad by design: the goal is to keep flows alive
  regardless of which specific storage error occurs. Narrowing to specific
  sqlite3 / OSError subtypes would require importing sqlite3 into cache.py and
  enumerating future storage backends' exception types — unnecessary coupling.
- On a read failure the flow is treated as a cache miss and forwarded to origin,
  which may increase origin load under sustained storage errors. This is
  preferable to aborting flows entirely.
