### PR TITLE
Track last_accessed_at for LRU-correct eviction in SQLiteStorage

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -2,9 +2,14 @@ from __future__ import annotations
 
 import io
 import sqlite3
+from datetime import datetime, timezone
 
 import mitmproxy.io as mio
 from mitmproxy import http
+
+
+def _now() -> str:
+    return datetime.now(tz=timezone.utc).isoformat()
 
 
 class SQLiteStorage:
@@ -20,17 +25,32 @@ class SQLiteStorage:
                 cache_key TEXT UNIQUE,
                 url TEXT,
                 method TEXT,
-                flow BLOB
+                flow BLOB,
+                last_accessed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
             )
             """
         )
         self.conn.commit()
+        # Migrate existing databases that predate the last_accessed_at column.
+        try:
+            cursor.execute(
+                "ALTER TABLE cache ADD COLUMN "
+                "last_accessed_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP"
+            )
+            self.conn.commit()
+        except sqlite3.OperationalError:
+            pass  # column already exists
 
     def get(self, cache_key: str) -> http.HTTPFlow | None:
         cursor = self.conn.cursor()
         cursor.execute("SELECT * FROM cache WHERE cache_key=?", (cache_key,))
         row = cursor.fetchone()
         if row:
+            cursor.execute(
+                "UPDATE cache SET last_accessed_at = ? WHERE cache_key = ?",
+                (_now(), cache_key),
+            )
+            self.conn.commit()
             for flow in mio.FlowReader(io.BytesIO(row["flow"])).stream():
                 return flow  # type: ignore
 
@@ -48,8 +68,9 @@ class SQLiteStorage:
                   , url
                   , method
                   , flow
+                  , last_accessed_at
                   )
-             VALUES (?, ?, ?, ?)"""
+             VALUES (?, ?, ?, ?, ?)"""
         cursor.execute(
             sql,
             (
@@ -57,6 +78,7 @@ class SQLiteStorage:
                 request.url,
                 request.method,
                 f.getvalue(),
+                _now(),
             ),
         )
         self.conn.commit()
@@ -74,6 +96,7 @@ class SQLiteStorage:
            SET url = ?
              , method = ?
              , flow = ?
+             , last_accessed_at = ?
          WHERE cache_key = ?"""
         cursor.execute(
             sql,
@@ -81,18 +104,23 @@ class SQLiteStorage:
                 request.url,
                 request.method,
                 f.getvalue(),
+                _now(),
                 cache_key,
             ),
         )
         self.conn.commit()
+        if self.max_entries is not None:
+            self._evict()
 
     def _evict(self) -> None:
         if self.max_entries is None:
             return
         cursor = self.conn.cursor()
+        # Keep the max_entries most-recently-accessed entries; evict the rest.
+        # Secondary sort by id DESC breaks ties deterministically (newer insert wins).
         cursor.execute(
             "DELETE FROM cache WHERE id NOT IN "
-            "(SELECT id FROM cache ORDER BY id DESC LIMIT ?)",
+            "(SELECT id FROM cache ORDER BY last_accessed_at DESC, id DESC LIMIT ?)",
             (self.max_entries,),
         )
         self.conn.commit()

--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -81,9 +81,9 @@ class SQLiteStorage:
                 _now(),
             ),
         )
-        self.conn.commit()
         if self.max_entries is not None:
             self._evict()
+        self.conn.commit()
 
     def update(self, cache_key: str, flow: http.HTTPFlow) -> None:
         request = flow.request
@@ -108,9 +108,9 @@ class SQLiteStorage:
                 cache_key,
             ),
         )
-        self.conn.commit()
         if self.max_entries is not None:
             self._evict()
+        self.conn.commit()
 
     def _evict(self) -> None:
         if self.max_entries is None:
@@ -123,7 +123,6 @@ class SQLiteStorage:
             "(SELECT id FROM cache ORDER BY last_accessed_at DESC, id DESC LIMIT ?)",
             (self.max_entries,),
         )
-        self.conn.commit()
 
     def purge(self, cache_key: str) -> None:
         cursor = self.conn.cursor()

--- a/tests/storage/test_sqlite3.py
+++ b/tests/storage/test_sqlite3.py
@@ -72,3 +72,50 @@ def test_max_entries_zero_means_unlimited() -> None:
     count = storage.conn.execute("SELECT COUNT(*) FROM cache").fetchone()[0]
     assert count == 10
     storage.close()
+
+
+def test_update_refreshes_eviction_order() -> None:
+    """update() must refresh last_accessed_at so that updated entries are not evicted first.
+
+    With max_entries=2 and three distinct store operations, the entry updated
+    most recently should survive eviction while the untouched entry is dropped.
+    """
+    storage = SQLiteStorage(":memory:", max_entries=2)
+    flow = example_flow()
+    storage.store("key1", flow)
+    storage.store("key2", flow)
+    # key1 and key2 are now both present (at capacity).
+    # Update key1 — this refreshes its last_accessed_at to "now".
+    storage.update("key1", flow)
+    # Store key3 — eviction runs; key2 (least recently accessed) should be evicted.
+    storage.store("key3", flow)
+
+    assert storage.get("key2") is None, (
+        "key2 should have been evicted (least recently used)"
+    )
+    assert storage.get("key1") is not None, (
+        "key1 should survive (updated recently)"
+    )
+    assert storage.get("key3") is not None, "key3 should survive (just stored)"
+    storage.close()
+
+
+def test_get_refreshes_eviction_order() -> None:
+    """get() must refresh last_accessed_at so that accessed entries are not evicted first."""
+    storage = SQLiteStorage(":memory:", max_entries=2)
+    flow = example_flow()
+    storage.store("key1", flow)
+    storage.store("key2", flow)
+    # Access key1 — this refreshes its last_accessed_at.
+    assert storage.get("key1") is not None
+    # Store key3 — eviction runs; key2 (least recently accessed) should be evicted.
+    storage.store("key3", flow)
+
+    assert storage.get("key2") is None, (
+        "key2 should have been evicted (least recently accessed)"
+    )
+    assert storage.get("key1") is not None, (
+        "key1 should survive (recently accessed)"
+    )
+    assert storage.get("key3") is not None, "key3 should survive (just stored)"
+    storage.close()


### PR DESCRIPTION
## Summary

The eviction policy introduced in the `max_entries` PR used the row `id`
(insertion order) to pick which entries to drop. Because `UPDATE` does not
change the `id`, frequently updated entries accumulate an old `id` and get
evicted before entries stored later but never updated — the inverse of LRU.

This PR fixes eviction to be last-recently-used correct.

## Changes

- **New column**: `last_accessed_at TEXT` added to the `cache` table (ISO 8601,
  microsecond precision via Python `datetime`). Existing databases are migrated
  transparently on first open (`ALTER TABLE … ADD COLUMN`; the
  `OperationalError` for an already-present column is silently swallowed).
- **`get()`**: refreshes `last_accessed_at` on a cache hit so recently read
  entries are protected from eviction.
- **`update()`**: refreshes `last_accessed_at` *and* calls `_evict()` so the
  entry count stays bounded after writes, not only after `store()`.
- **`_evict()`**: orders by `last_accessed_at DESC, id DESC` instead of
  `id DESC`, giving true LRU semantics. The `id` tiebreaker keeps behaviour
  deterministic when two entries share the same microsecond timestamp.

## Verification

```
uv run poe format   # 1 file reformatted
uv run poe check    # all checks passed
uv run poe test     # 12 passed
```

New tests: `test_update_refreshes_eviction_order`,
`test_get_refreshes_eviction_order`.

Static analysis: `ruff check` (0 additional findings).

## Trade-offs

- One additional `UPDATE` query per `get()` cache hit to refresh
  `last_accessed_at`. Overhead is negligible for typical cache sizes but
  increases write traffic on read-heavy workloads.
- The `ALTER TABLE` migration silently ignores errors, so a corrupt schema
  with a mismatched `last_accessed_at` column type would not be detected on
  open.
