### PR TITLE
Strip internal cache key header from all responses

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -87,7 +87,6 @@ class Cache:
                 assert cache.response is not None
                 logger.info(f"Cache hit: {_sanitize_for_log(cache_key)}")
                 flow.response = cache.response
-                flow.response.headers[self.cache_key] = cache_key
                 flow.metadata[self.cache_key] = cache_key
                 cache_from_origin = False
         else:
@@ -107,6 +106,10 @@ class Cache:
         if getattr(self, "_closed", False):
             logger.warning("Cache.response() called after done(); skipping.")
             return
+
+        # Strip internal header so it never reaches the downstream client.
+        flow.response.headers.pop(self.cache_key, None)
+
         # Check if the response has a cache key
         cache_key = self.get_cache_key_from_flow(flow)
         if flow.metadata.get(self.cache_from_origin, False) and cache_key:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -217,6 +217,52 @@ def test_request_and_response_after_done_are_no_ops() -> None:
         assert addon._closed is False
 
 
+def test_cache_key_header_not_leaked_to_client() -> None:
+    """Internal cache key header must not appear in the response seen by clients.
+
+    On a cache hit, the addon must not expose the proxy-internal
+    header to downstream consumers.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+
+        # First request: populate the cache.
+        flow_store = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"leak-test-key")],
+            ),
+            resp=tutils.tresp(
+                content=b"Cached body",
+                status_code=200,
+            ),
+        )
+        addon.request(flow_store)
+        addon.response(flow_store)
+
+        # Second request: cache hit.
+        flow_hit = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"leak-test-key")],
+            ),
+            resp=False,
+        )
+        addon.request(flow_hit)
+        assert flow_hit.response is not None
+        addon.response(flow_hit)
+
+        # The internal header must not be present in the response forwarded to
+        # the client.
+        assert addon.cache_key not in flow_hit.response.headers
+
+        addon.done()
+
+
 def test_get_cache_key_from_flow() -> None:
     """Confirm that the cache key is extracted from the flow."""
     with taddons.context() as tctx:


### PR DESCRIPTION
## Summary

On a cache hit, `request()` wrote the proxy-internal `Mitm-Cache-Key`
header directly into `flow.response.headers`. Because `response()` never
stripped it, the header was forwarded to downstream clients, leaking the
proxy key (a UUID or user-supplied string).

- Remove the `flow.response.headers[self.cache_key] = cache_key` write
  in `request()`: the key is already tracked in `flow.metadata`, which
  `cache_key_candidates()` checks first, so the response header write
  was redundant.
- Add `flow.response.headers.pop(self.cache_key, None)` at the start of
  `response()` so any stray occurrence of the header (e.g. origin server
  sending a header with the same name) is also stripped before the
  response reaches the client.

## Test plan

- `test_cache_key_header_not_leaked_to_client`: new test that stores a
  response, triggers a cache hit, and asserts the internal header is
  absent from the response after `response()` runs.
- All existing tests pass (`uv run poe test` → 9 passed).
- `uv run poe check` (ruff) → 0 findings.
- Adjacent static check: `uvx vulture mitmcache` → 5 findings, all
  mitmproxy lifecycle hooks (`configure`, `done`, `purge`) called by the
  framework — not actionable.

## Trade-offs

- `cache_key_candidates()` still reads `flow.response.headers` as a
  fallback, but since `response()` now strips the internal header first,
  that path will no longer match the internal key. Any future external
  caller that relied on the response header carrying the key would need
  to use `flow.metadata` instead.
