### PR TITLE
Recreate storage when cache_max_entries option changes

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -36,7 +36,11 @@ class Cache:
 
     def configure(self, updated: set[str]) -> None:
         existing = getattr(self, "storage", None)
-        if existing is not None and "cache_file" not in updated:
+        if (
+            existing is not None
+            and "cache_file" not in updated
+            and "cache_max_entries" not in updated
+        ):
             return
         if existing is not None:
             existing.close()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -132,6 +132,11 @@ def test_configure_closes_previous_storage() -> None:
         addon.configure({"cache_key"})
         assert addon.storage is current
 
+        # configure with cache_max_entries must recreate storage so the new
+        # value takes effect.
+        addon.configure({"cache_max_entries"})
+        assert addon.storage is not current
+
         addon.done()
 
 


### PR DESCRIPTION
## Summary

`configure()` only triggered storage recreation when `cache_file` changed.
Changing `cache_max_entries` at runtime (via the mitmproxy CLI or API)
had no effect — the existing `SQLiteStorage` instance kept its original
`max_entries` value and the new limit was silently ignored.

Add `"cache_max_entries" not in updated` to the early-return guard so
that a `max_entries` change triggers the same close-and-recreate path
as a `cache_file` change.

## Test plan

- Extended `test_configure_closes_previous_storage` with a
  `configure({"cache_max_entries"})` call that asserts storage is
  recreated.
- All existing tests pass (`uv run poe test` → 8 passed).
- `uv run poe check` (ruff) → 0 findings.
- Adjacent static check: `uvx vulture mitmcache` → 5 findings, all
  mitmproxy lifecycle hooks — not actionable.

## Trade-offs

- Storage is closed and reopened on every `cache_max_entries` change.
  For the typical use case (set once at startup or changed infrequently)
  this is fine. Rapid repeated changes would close/reopen unnecessarily,
  but that pattern is not expected in practice.
