### PR TITLE
fix: assign new storage before closing old to prevent closed-storage access

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -38,9 +38,9 @@ class Cache:
         existing = getattr(self, "storage", None)
         if existing is not None and "cache_file" not in updated:
             return
+        self.storage = self.storage_factory.create()
         if existing is not None:
             existing.close()
-        self.storage = self.storage_factory.create()
 
     @property
     def cache_key(self) -> str:


### PR DESCRIPTION
## Summary

Reorder `configure()` operations from close-then-assign to create-assign-close to eliminate a race window where concurrent hooks could access a closed storage.

**Before:**
```python
if existing is not None:
    existing.close()        # storage is now closed
self.storage = self.storage_factory.create()  # gap: hook sees closed storage
```

**After:**
```python
self.storage = self.storage_factory.create()  # new storage is live immediately
if existing is not None:
    existing.close()        # old storage is closed after swap
```

## Motivation

Between `existing.close()` and the `self.storage = ...` assignment, a concurrent `request()` or `response()` hook accessing `self.storage` would encounter an already-closed SQLite connection, raising `ProgrammingError: Cannot operate on a closed database`.

Under CPython's GIL, attribute assignment is atomic. After this change, hooks always see either the old (valid) or the new (valid) storage — the closed-storage window is eliminated.

## Verification

- `ruff check`: pass
- `pytest tests`: 8/8 passed
- `vulture mitmcache/`: no dead code
