### PR TITLE
fix: make INSERT and eviction DELETE atomic in a single transaction

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -81,9 +81,9 @@ class SQLiteStorage:
                 _now(),
             ),
         )
-        self.conn.commit()
         if self.max_entries is not None:
             self._evict()
+        self.conn.commit()
 
     def update(self, cache_key: str, flow: http.HTTPFlow) -> None:
         request = flow.request
@@ -108,9 +108,9 @@ class SQLiteStorage:
                 cache_key,
             ),
         )
-        self.conn.commit()
         if self.max_entries is not None:
             self._evict()
+        self.conn.commit()
 
     def _evict(self) -> None:
         if self.max_entries is None:
@@ -123,7 +123,6 @@ class SQLiteStorage:
             "(SELECT id FROM cache ORDER BY last_accessed_at DESC, id DESC LIMIT ?)",
             (self.max_entries,),
         )
-        self.conn.commit()
 
     def purge(self, cache_key: str) -> None:
         cursor = self.conn.cursor()


### PR DESCRIPTION
## Summary

`store()` and `update()` committed the INSERT/UPDATE before calling `_evict()`,
leaving a window where concurrent readers could observe an over-limit entry
that was about to be deleted. On mitmproxy's default multi-threaded executor
this is a real race condition, not just a theoretical one.

## Changes

- Move `_evict()` call to *before* `self.conn.commit()` in both `store()` and `update()`
- Remove the `self.conn.commit()` inside `_evict()` — the caller now commits once,
  covering both the write and the eviction DELETE in a single transaction

## Verification

- All 12 existing unit tests pass
- `ruff check` / `ruff format` — no issues
- `vulture` — no dead code findings