### PR TITLE
fix: log warning when update() targets a non-existent cache key

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
 import io
+import logging
 import sqlite3
 
 import mitmproxy.io as mio
 from mitmproxy import http
+
+logger = logging.getLogger(__name__)
 
 
 class SQLiteStorage:
@@ -81,6 +84,8 @@ class SQLiteStorage:
                 cache_key,
             ),
         )
+        if cursor.rowcount == 0:
+            logger.warning("update() noop: cache_key %r not found", cache_key)
         self.conn.commit()
 
     def purge(self, cache_key: str) -> None:


### PR DESCRIPTION
## Summary

`SQLiteStorage.update()` ran `conn.commit()` without checking `cursor.rowcount`,
so a concurrent `purge()` that deleted the entry between `get()` and `update()`
would silently drop the cache write with no log or exception.

## Changes

- Import `logging` and create a module-level `logger` in `sqlite3.py`
- After the UPDATE execute, check `cursor.rowcount == 0` and emit a
  `logger.warning(...)` so the noop is visible in standard log streams
  (mitmproxy's logging pipeline, Sentry integrations, etc.)

## Verification

- All 8 unit tests pass
- `ruff format` / `ruff check` — no issues
- `vulture` — no dead code findings