### PR TITLE
Fix StorageFactory docstring to reflect only SQLiteStorage is supported

### DIFF
--- a/mitmcache/storage/factory.py
+++ b/mitmcache/storage/factory.py
@@ -1,13 +1,8 @@
-"""Factory of Storage
+"""Factory for Storage initialization.
 
-There are many Storage classes, such as
-- SQLiteStorage
-- RedisStorage
-- FileStorage
-- etc.
-
-StorageFactory knows how to initialize them.
-So, the user of Storage does not need to know how to initialize them.
+Currently only SQLiteStorage is supported.
+StorageFactory initializes it from mitmproxy options, so callers do not
+need to know the constructor details.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## What changed

The module docstring in `mitmcache/storage/factory.py` listed `RedisStorage` and `FileStorage` as examples of storage classes that `StorageFactory` knows how to initialize. Neither of those implementations exists in the codebase, so the docstring was making a promise the code could not keep.

The docstring has been rewritten to accurately describe what the module actually does: initialize `SQLiteStorage` from mitmproxy options, so callers do not need to know the constructor details.

## Why

Listing non-existent classes in a docstring misleads contributors and users into thinking alternative storage backends are already available or are otherwise part of the design. Aligning documentation with the real implementation removes that confusion.

## Scope

Documentation-only change. No logic, behavior, or public API is affected. No new tests are needed.
