### PR TITLE
Add cache_max_body_size option to skip caching large responses

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -126,14 +126,7 @@ class Cache:
         # indefinitely even after the origin recovers.
         if flow.response is None or flow.response.status_code >= 400:
             return
-        max_size = int(ctx.options.cache_max_body_size)
-        if max_size > 0 and len(flow.response.content) > max_size:
-            logger.warning(
-                f"Cache skipped: body "
-                f"{len(flow.response.content)} bytes "
-                f"> cache_max_body_size {max_size} "
-                f"({_sanitize_for_log(cache_key)})"
-            )
+        if self._response_body_exceeds_limit(flow, cache_key):
             return
         try:
             self.storage.upsert(cache_key, flow)
@@ -143,6 +136,24 @@ class Cache:
                 "Cache storage write failed for key %s; response not cached",
                 _sanitize_for_log(cache_key),
             )
+
+    def _response_body_exceeds_limit(
+        self, flow: http.HTTPFlow, cache_key: str
+    ) -> bool:
+        max_size = int(ctx.options.cache_max_body_size)
+        if (
+            max_size > 0
+            and flow.response is not None
+            and len(flow.response.content) > max_size
+        ):
+            logger.warning(
+                f"Cache skipped: body "
+                f"{len(flow.response.content)} bytes "
+                f"> cache_max_body_size {max_size} "
+                f"({_sanitize_for_log(cache_key)})"
+            )
+            return True
+        return False
 
     def _set_cached_response(self, flow: HTTPFlow, cache_key: str) -> bool:
         """Best-effort cache read; storage failures bypass the cache."""

--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -33,6 +33,15 @@ class Cache:
             " response should be fetched from the origin (not an HTTP"
             " header name).",
         )
+        loader.add_option(
+            name="cache_max_body_size",
+            typespec=int,
+            default=0,
+            help=(
+                "Maximum response body size in bytes to cache. "
+                "0 means no limit. Responses larger than this are skipped."
+            ),
+        )
         self.storage_factory = StorageFactory()
         self.storage_factory.load(loader)
 
@@ -116,6 +125,15 @@ class Cache:
         # Do not cache error responses; a cached 4xx/5xx would be served
         # indefinitely even after the origin recovers.
         if flow.response is None or flow.response.status_code >= 400:
+            return
+        max_size = int(ctx.options.cache_max_body_size)
+        if max_size > 0 and len(flow.response.content) > max_size:
+            logger.warning(
+                f"Cache skipped: body "
+                f"{len(flow.response.content)} bytes "
+                f"> cache_max_body_size {max_size} "
+                f"({_sanitize_for_log(cache_key)})"
+            )
             return
         try:
             self.storage.upsert(cache_key, flow)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -376,6 +376,34 @@ def test_cache_key_header_not_leaked_to_client() -> None:
         addon.done()
 
 
+def test_large_response_skipped_when_max_body_size_set() -> None:
+    """Responses exceeding cache_max_body_size must not be stored."""
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        tctx.configure(addon, cache_max_body_size=10)
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
+
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"big-key")],
+            ),
+            resp=tutils.tresp(
+                content=b"X" * 11,  # 11 bytes > limit of 10
+                status_code=200,
+            ),
+        )
+        addon.request(flow)
+        addon.response(flow)
+        assert storage.store_count == 0
+        assert storage.update_count == 0
+        assert storage.upsert_count == 0
+        addon.done()
+
+
 def test_get_cache_key_from_flow() -> None:
     """Confirm that the cache key is extracted from the flow."""
     with taddons.context() as tctx:


### PR DESCRIPTION
## Motivation

When mitmproxy passes through large responses such as video streams,
serializing the response body into both an in-memory BytesIO buffer and a
SQLite BLOB can temporarily consume more than twice the body size in memory.
There was no built-in way to opt out of caching oversized responses.

## Changes

- Added a `cache_max_body_size` option (int, default `0` = no limit) to
  `Cache.load()`.
- In `Cache.response()`, the response body size is checked against
  `cache_max_body_size` before writing to storage. If the body exceeds the
  limit, a warning is logged and the response is passed through without being
  cached.

## Scope

Only `mitmcache/cache.py` is changed. Storage backends and the request path
are not affected.

## Test verification

Added `test_large_response_skipped_when_max_body_size_set`: sets
`cache_max_body_size=10`, sends a response with an 11-byte body, and asserts
that neither `store_count` nor `update_count` increases.
