### PR TITLE
Guard request() and response() against calls after done()

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -41,6 +41,7 @@ class Cache:
         if existing is not None:
             existing.close()
         self.storage = self.storage_factory.create()
+        self._closed = False
 
     @property
     def cache_key(self) -> str:
@@ -60,6 +61,9 @@ class Cache:
         3. If the request doesn't have a cache key,
           generate a cache key and set it to the response headers.
         """
+        if getattr(self, "_closed", False):
+            logger.warning("Cache.request() called after done(); skipping.")
+            return
         # Get cache key or create it from request headers
         cache_key = self.get_cache_key_from_flow(flow)
         # Cache key header is a proxy-internal hint; never forward it to the
@@ -94,7 +98,9 @@ class Cache:
         2. If the response doesn't have a cache key,
            that means the request has sent to the origin and it will be cached.
         """
-
+        if getattr(self, "_closed", False):
+            logger.warning("Cache.response() called after done(); skipping.")
+            return
         # Check if the response has a cache key
         cache_key = self.get_cache_key_from_flow(flow)
         if flow.metadata.get(self.cache_from_origin, False) and cache_key:
@@ -125,6 +131,7 @@ class Cache:
 
     def done(self) -> None:
         self.storage.close()
+        self._closed = True
 
 
 def generate_cache_key_by_uuid() -> str:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -177,6 +177,40 @@ def test_cache_key_header_stripped_before_origin() -> None:
         addon.done()
 
 
+def test_request_and_response_after_done_are_no_ops() -> None:
+    """request() and response() called after done() must not raise.
+
+    Verifies the CLOSED state guard introduced to prevent
+    sqlite3.ProgrammingError when mitmproxy calls hooks after done().
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
+
+        addon.done()
+        assert addon._closed is True
+
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"key1")],
+            ),
+            resp=tutils.tresp(content=b"body"),
+        )
+        # Neither call should raise or touch storage.
+        addon.request(flow)
+        addon.response(flow)
+        assert storage.store_count == 0
+        assert storage.update_count == 0
+
+        # configure() reopens storage and clears the closed flag.
+        addon.configure({"cache_file"})
+        assert addon._closed is False
+
+
 def test_get_cache_key_from_flow() -> None:
     """Confirm that the cache key is extracted from the flow."""
     with taddons.context() as tctx:


### PR DESCRIPTION
## Summary

`Cache` had no state tracking after `done()` closed the storage connection.
If mitmproxy called `request()` or `response()` afterwards (e.g. on addon restart),
it would propagate an unhandled `sqlite3.ProgrammingError: Cannot operate on a closed database.`

This PR adds a `_closed` boolean flag that:

- Is set to `False` in `configure()` when a new storage is opened.
- Is set to `True` in `done()` after the connection is closed.
- Is checked at the top of `request()` and `response()` — both return early with a warning log instead of touching the closed storage.

`configure()` resets the flag, so the addon remains usable after reconfiguration.

## Changes

- `mitmcache/cache.py`: add `_closed` guard in `configure()`, `done()`, `request()`, `response()`
- `tests/test_cache.py`: add `test_request_and_response_after_done_are_no_ops` covering the CLOSED state

## Verification

All existing tests pass; the new test confirms that storage is not accessed after `done()` and that `configure()` reopens the addon correctly.

```
7 passed in 0.48s
```