### PR TITLE
Remove UUID fallback for keyless requests

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import logging
 import re
-from uuid import uuid4
 
 from mitmproxy import ctx, http
 from mitmproxy.addonmanager import Loader
@@ -73,28 +72,24 @@ class Cache:
           set the response to the cached response.
         2. If the request has a cache key but doesn't exist in the cache,
           request to the origin server without cache key header.
-        3. If the request doesn't have a cache key,
-          generate a cache key and set it to the response headers.
+        3. If the request doesn't have a cache key, forward to origin without
+          caching (no UUID fallback — keyless requests are not cacheable).
         """
         if getattr(self, "_closed", False):
             logger.warning("Cache.request() called after done(); skipping.")
             return
-        # Get cache key or create it from request headers
+        # Get cache key from request headers
         cache_key = self.get_cache_key_from_flow(flow)
         # Cache key header is a proxy-internal hint; never forward it to the
         # origin regardless of cache hit / miss / no-key. Pop once here so
         # all branches stay symmetric and a future branch cannot leak it.
         flow.request.headers.pop(self.cache_key, None)
-        search_cache = True if cache_key is not None else False
 
         cache_from_origin = True
 
         # Get response from cache
-        if search_cache and cache_key:
-            if self._set_cached_response(flow, cache_key):
-                cache_from_origin = False
-        else:
-            cache_key = generate_cache_key_by_uuid()
+        if cache_key is not None and self._set_cached_response(flow, cache_key):
+            cache_from_origin = False
 
         # Set cache key to flow
         flow.metadata[self.cache_key] = cache_key
@@ -202,11 +197,6 @@ class Cache:
         if storage is not None:
             storage.close()
         self._closed = True
-
-
-def generate_cache_key_by_uuid() -> str:
-    # Generate cache key by uuid
-    return str(uuid4())
 
 
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -247,8 +247,7 @@ def test_cache_key_header_stripped_before_origin() -> None:
         assert addon.cache_key not in flow_miss.request.headers
         assert flow_miss.metadata[addon.cache_key] == "miss-key"
 
-        # case2. no cache key -> auto-uuid path, header should be absent
-        # before forwarding to origin.
+        # case2. no cache key -> forwarded to origin without caching.
         flow_nokey = tflow.tflow(
             req=tutils.treq(
                 method=b"GET",
@@ -259,6 +258,7 @@ def test_cache_key_header_stripped_before_origin() -> None:
         )
         addon.request(flow_nokey)
         assert addon.cache_key not in flow_nokey.request.headers
+        assert flow_nokey.metadata[addon.cache_key] is None
 
         addon.done()
 
@@ -295,7 +295,6 @@ def test_request_and_response_after_done_are_no_ops() -> None:
         # configure() reopens storage and clears the closed flag.
         addon.configure({"cache_file"})
         assert addon._closed is False
-
 
 def test_error_response_not_cached() -> None:
     """Error responses (4xx/5xx) must not be stored in the cache.
@@ -401,6 +400,35 @@ def test_large_response_skipped_when_max_body_size_set() -> None:
         assert storage.store_count == 0
         assert storage.update_count == 0
         assert storage.upsert_count == 0
+        addon.done()
+
+
+def test_keyless_request_not_cached() -> None:
+    """Requests without a cache key must not be stored in the cache.
+
+    Previously a random UUID was assigned per request, causing unbounded
+    cache growth with entries that can never be reused. The fix removes
+    the UUID fallback entirely so keyless requests pass through to origin
+    without writing to storage.
+    """
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
+
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+            ),
+            resp=tutils.tresp(content=b"Hello"),
+        )
+        addon.request(flow)
+        addon.response(flow)
+
+        assert storage.store_count == 0
+        assert storage.update_count == 0
         addon.done()
 
 


### PR DESCRIPTION
## Summary

When a request carried no `Mitm-Cache-Key` header, `request()` previously
called `uuid4()` to assign a per-request identifier. Because the UUID was
never surfaced to the client (not sent back as a response header), every
subsequent request to the same URL generated a different UUID. The cached
entries were therefore unreachable, and storage grew without bound.

This PR removes the UUID fallback. Keyless requests now pass through to the
origin unchanged and are not written to storage. `storage.store()` is only
called when the flow carries a cache key supplied by the caller.

## Changes

- `mitmcache/cache.py`: remove `generate_cache_key_by_uuid()` call and the
  helper function; simplify the `if/else` in `request()` to a plain `if`;
  remove unused `from uuid import uuid4`
- `tests/test_cache.py`: update comment for the no-key path; add
  `test_keyless_request_not_cached` verifying storage is not touched

## Verification

All existing tests continue to pass; the new test confirms storage is not
written for keyless flows.

```
7 passed in 0.37s
```