### PR TITLE
Catch ValueError in StorageFactory.create() for invalid cache_max_entries

### DIFF
--- a/mitmcache/storage/factory.py
+++ b/mitmcache/storage/factory.py
@@ -12,16 +12,26 @@ So, the user of Storage does not need to know how to initialize them.
 
 from __future__ import annotations
 
+import logging
+
 from mitmproxy import ctx
 from mitmproxy.addonmanager import Loader
 
 from .cache_storage import CacheStorage
 from .sqlite3 import SQLiteStorage
 
+logger = logging.getLogger(__name__)
+
 
 class StorageFactory:
     def create(self) -> CacheStorage:
-        raw = int(ctx.options.cache_max_entries)
+        try:
+            raw = int(ctx.options.cache_max_entries)
+        except (ValueError, TypeError):
+            logger.warning(
+                "cache_max_entries is not a valid integer; defaulting to unlimited."
+            )
+            raw = 0
         max_entries = raw if raw > 0 else None
         return SQLiteStorage(ctx.options.cache_file, max_entries=max_entries)
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -235,3 +235,27 @@ def test_get_cache_key_from_flow() -> None:
         assert addon.get_cache_key_from_flow(flow) is None
 
         addon.done()
+
+
+def test_storage_factory_invalid_max_entries_defaults_to_unlimited() -> None:
+    """StorageFactory.create() must not raise on non-integer cache_max_entries.
+
+    mitmproxy's typespec=int normally prevents this, but defensive coding
+    requires a try/except guard for edge cases such as typespec bypass or
+    future runtime changes.
+    """
+    from unittest.mock import MagicMock, patch
+
+    from mitmcache.storage.factory import StorageFactory
+
+    factory = StorageFactory()
+    mock_options = MagicMock()
+    mock_options.cache_max_entries = "not-an-int"
+    mock_options.cache_file = ":memory:"
+
+    with patch("mitmcache.storage.factory.ctx") as mock_ctx:
+        mock_ctx.options = mock_options
+        storage = factory.create()
+
+    assert storage is not None
+    storage.close()


### PR DESCRIPTION
## Summary

`StorageFactory.create()` called `int(ctx.options.cache_max_entries)` without
a `try/except`. mitmproxy's `typespec=int` validation normally guarantees the
value is an integer before `create()` is called, but there are edge cases where
conversion can fail: programmatic option access bypassing the typespec pipeline,
or future mitmproxy internals changes. An unhandled `ValueError` here propagates
to addon load time and silently disables the entire addon.

This PR wraps the `int()` call in a `try/except (ValueError, TypeError)` block.
On failure it logs a warning and falls back to `max_entries=None` (unlimited),
so the addon remains functional with a clear diagnostic message.

**Note:** this fix is relative to `fix/sqlite-cache-max-entries-eviction` (PR #116),
which introduces `cache_max_entries`. It should be merged after #116.

## Changes

- `mitmcache/storage/factory.py`: add `logging`; wrap `int(cache_max_entries)` in
  `try/except (ValueError, TypeError)` with warning fallback to unlimited
- `tests/test_cache.py`: add `test_storage_factory_invalid_max_entries_defaults_to_unlimited`
  verifying the guard with a patched non-integer option value

## Verification

All existing tests pass; the new test confirms the factory does not raise and
returns a valid storage instance when `cache_max_entries` is not a valid integer.

```
7 passed in 0.36s
```