### PR TITLE
fix: treat empty string as a valid cache key in get_cache_key_from_flow

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -108,7 +108,7 @@ class Cache:
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
         for candidate in self.cache_key_candidates(flow):
-            if candidate:
+            if candidate is not None:
                 return str(candidate)
         return None
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -234,4 +234,16 @@ def test_get_cache_key_from_flow() -> None:
         )
         assert addon.get_cache_key_from_flow(flow) is None
 
+        # case5. empty header value is a valid cache key (not silently skipped)
+        flow = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"")],
+            ),
+            resp=False,
+        )
+        assert addon.get_cache_key_from_flow(flow) == ""
+
         addon.done()


### PR DESCRIPTION
## Summary

`get_cache_key_from_flow()` used `if candidate:` to select the first non-falsy cache key candidate, which silently discards empty strings and empty bytes. Sending `Mitm-Cache-Key:` with an empty value would therefore fall through to UUID auto-generation rather than using the supplied (empty) key.

## Changes

- `mitmcache/cache.py`: change guard from `if candidate:` to `if candidate is not None:` so that any explicitly-provided value, including the empty string, is used as the cache key.
- `tests/test_cache.py`: add case 5 verifying that an empty header value is returned as-is instead of being discarded.

## Verification

```
$ uv run poe test
8 passed, 2 warnings in 0.42s
$ uv run poe check
All checks passed!
```

## Trade-offs

An empty string `""` is now a valid cache key. Callers that previously relied on the implicit falsy-skip behaviour (e.g., sending an empty header expecting UUID fallback) will see a change: they now get a cache bucket keyed by `""`. This matches the documented contract—`Mitm-Cache-Key` specifies the cache key—and is more predictable than silent coercion.
