### PR TITLE
fix: correct cache_from_origin option help text

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -28,8 +28,9 @@ class Cache:
             name="cache_from_origin",
             typespec=str,
             default="Mitm-Cache-From-Origin",
-            help="Header used to determine\
- whether the request is from the origin",
+            help="flow.metadata key used internally to track whether the"
+            " response should be fetched from the origin (not an HTTP"
+            " header name).",
         )
         self.storage_factory = StorageFactory()
         self.storage_factory.load(loader)


### PR DESCRIPTION
## Summary

The `cache_from_origin` option help text said "Header used to determine whether the request is from the origin", which incorrectly implies that this option is an HTTP header name (as `cache_key` is). In reality the value is used as a `flow.metadata` key to carry a boolean flag between the `request()` and `response()` hooks; it never reads from HTTP headers.

## Changes

- `mitmcache/cache.py`: replace the misleading help string with an accurate description: *"flow.metadata key used internally to track whether the response should be fetched from the origin (not an HTTP header name)."*

## Verification

```
$ uv run poe test
8 passed, 2 warnings in 0.38s
$ uv run poe check
All checks passed!
```

## Trade-offs

No behaviour change — the option name, default value, and runtime logic are untouched. Only the help text visible in `mitmdump --options` is corrected.
