### PR TITLE
fix: sanitize cache key before logging to prevent log injection

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from uuid import uuid4
 
 from mitmproxy import ctx, http
@@ -75,7 +76,7 @@ class Cache:
             cache = self.storage.get(cache_key)
             if cache is not None:
                 assert cache.response is not None
-                logger.info(f"Cache hit: {cache_key}")
+                logger.info(f"Cache hit: {_sanitize_for_log(cache_key)}")
                 flow.response = cache.response
                 flow.response.headers[self.cache_key] = cache_key
                 flow.metadata[self.cache_key] = cache_key
@@ -101,10 +102,10 @@ class Cache:
             cache = self.storage.get(cache_key)
             if cache is not None:
                 self.storage.update(cache_key, flow)
-                logger.info(f"Cache updated: {cache_key}")
+                logger.info(f"Cache updated: {_sanitize_for_log(cache_key)}")
             else:
                 self.storage.store(cache_key, flow)
-                logger.info(f"Cache stored: {cache_key}")
+                logger.info(f"Cache stored: {_sanitize_for_log(cache_key)}")
 
     def get_cache_key_from_flow(self, flow: HTTPFlow) -> str | None:
         for candidate in self.cache_key_candidates(flow):
@@ -130,3 +131,11 @@ class Cache:
 def generate_cache_key_by_uuid() -> str:
     # Generate cache key by uuid
     return str(uuid4())
+
+
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+
+
+def _sanitize_for_log(value: str) -> str:
+    """Escape control characters so external input cannot inject log lines."""
+    return _CONTROL_CHARS_RE.sub(lambda m: f"\\x{ord(m.group()):02x}", value)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from mitmproxy.addons import script
 from mitmproxy.test import taddons, tflow, tutils
 
+from mitmcache.cache import _sanitize_for_log
 from mitmcache.storage.cache_storage import CacheStorage
 
 from .example_flow import example_flow
@@ -235,3 +236,12 @@ def test_get_cache_key_from_flow() -> None:
         assert addon.get_cache_key_from_flow(flow) is None
 
         addon.done()
+
+
+def test_sanitize_for_log() -> None:
+    """Control characters in cache keys must be escaped before logging."""
+    assert _sanitize_for_log("normal-key") == "normal-key"
+    assert _sanitize_for_log("key\nINFO fake") == "key\\x0aINFO fake"
+    assert _sanitize_for_log("key\r\n") == "key\\x0d\\x0a"
+    assert _sanitize_for_log("\x1b[31mred\x1b[0m") == "\\x1b[31mred\\x1b[0m"
+    assert _sanitize_for_log("") == ""


### PR DESCRIPTION
## Summary

Cache keys originate from the `Mitm-Cache-Key` HTTP header — a value controlled by any client connecting through the proxy. Those values are passed directly into `logger.info()` at three call sites. A client can craft a header containing newlines (`\n`) or ANSI escape sequences to inject fake log lines into the log file or corrupt terminal output.

## Changes

- `mitmcache/cache.py`: add `_sanitize_for_log(value: str) -> str` which replaces every control character (`\x00`–`\x1f`, `\x7f`) with its `\xNN` hex escape before the value reaches the log sink. Apply it to all three `logger.info()` call sites: *Cache hit*, *Cache updated*, *Cache stored*.
- `tests/test_cache.py`: add `test_sanitize_for_log` covering newline injection, CR+LF, ANSI escape sequences (`\x1b[…m`), a normal key, and an empty string.

## Verification

```
$ uv run poe test
9 passed, 2 warnings in 0.39s
$ uv run poe check
All checks passed!
```

## Trade-offs

Control characters in log output are replaced by `\xNN` hex escapes. Legitimate keys containing control characters (unlikely in practice) will appear escaped in logs. The cache storage key itself is **not** changed — only the log representation is affected.

The scope is limited to the log layer. The cache key is still stored and compared verbatim; this fix does not alter cache behaviour.
