### PR TITLE
fix: close BytesIO buffer explicitly in SQLiteStorage.get()

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -30,8 +30,9 @@ class SQLiteStorage:
         cursor.execute("SELECT * FROM cache WHERE cache_key=?", (cache_key,))
         row = cursor.fetchone()
         if row:
-            for flow in mio.FlowReader(io.BytesIO(row["flow"])).stream():
-                return flow  # type: ignore
+            with io.BytesIO(row["flow"]) as buf:
+                for flow in mio.FlowReader(buf).stream():
+                    return flow  # type: ignore
 
         return None
 


### PR DESCRIPTION
## Summary

Wrap the `BytesIO` buffer in `SQLiteStorage.get()` with a `with` statement so the buffer is closed explicitly after reading the first flow.

## Changes

- `mitmcache/storage/sqlite3.py` — `SQLiteStorage.get()`: replaced bare `io.BytesIO(row["flow"])` with `with io.BytesIO(row["flow"]) as buf` to ensure the buffer is explicitly closed when the block exits.

## Motivation

The previous code returned from inside the `for` loop immediately after obtaining the first flow, leaving the `BytesIO` buffer's lifetime entirely dependent on garbage collection. Under high cache-read load, many such buffers could accumulate before GC reclaims them, increasing peak memory usage unnecessarily. Using a `with` block ensures the buffer is released as soon as the flow is obtained, regardless of GC scheduling.

## Scope

Single method change in `mitmcache/storage/sqlite3.py`. The `store()` and `update()` methods also construct `BytesIO` buffers, but they call `getvalue()` to extract the bytes before the buffer goes out of scope; those buffers are not retained across calls and are not affected by this change.

## Verification

- All existing tests pass.
- `ruff check` passes with no errors.
