### PR TITLE
Drop Python 3.10/3.11, upgrade to mitmproxy 12.2.3 to resolve security CVEs

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -130,8 +130,9 @@ class SQLiteStorage:
                   , url
                   , method
                   , flow
+                  , flow_format_version
                   )
-             VALUES (?, ?, ?, ?)"""
+             VALUES (?, ?, ?, ?, ?)"""
         cursor.execute(
             sql,
             (
@@ -139,6 +140,7 @@ class SQLiteStorage:
                 request.url,
                 request.method,
                 f.getvalue(),
+                _MITMPROXY_VERSION,
             ),
         )
         self.conn.commit()

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.12
 warn_return_any = True
 warn_unused_configs = True
 disallow_untyped_defs = True


### PR DESCRIPTION
## Summary

mitmproxy 10.3.0 (used on Python <3.12) pins h11<=0.14.0, blocking the fix
for h11 CVE-2025-43859 (critical, HTTP request smuggling). No mitmproxy
version for Python <3.12 allows h11>=0.16.0, so the only viable path is to
drop those Python versions.

mitmproxy 12.2.3 relaxes the pyOpenSSL upper bound to <=27.0.0 (was <=25.3.0
in 12.2.2), which allows upgrading pyOpenSSL to 26.2.0.

## Changes

- `requires-python`: `>=3.10` -> `>=3.12`
- Single `mitmproxy==12.2.3` dependency (replaces conditional 10.3.0/12.2.2)
- `mypy.ini` `python_version`: `3.10` -> `3.12`
- CI matrix: remove Python 3.10 and 3.11
- `uv.lock`: regenerated; pyOpenSSL upgraded to 26.2.0

## CVEs resolved

| Package | Before | After | Severity |
|---------|--------|-------|----------|
| h11 | 0.14.0 | 0.16.0 | Critical (CVE-2025-43859) |
| brotli | 1.1.0 | 1.2.0 | High (CVE-2025-6176) |
| cryptography | 42.0.8 | 46.0.7 | High (CVE-2026-26007, others) |
| pyopenssl | 24.1.0 | 26.2.0 | High (CVE-2026-27459), Low (CVE-2026-27448) |
| flask | 3.0.3 | 3.1.3 | Low (CVE-2026-27205) |
| mitmproxy | 10.3.0 / 12.2.2 | 12.2.3 | -- |

## Verification

- `uv run poe test`: 8/8 passed
- `uv run poe check`: no issues
- `uv run mypy mitmcache`: no issues

## Trade-off

Users on Python 3.10 and 3.11 must upgrade their runtime. Python 3.10
reaches EOL October 2026.
