### PR TITLE
Close SQLite connection in __init__ if schema setup raises

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -11,19 +11,23 @@ class SQLiteStorage:
     def __init__(self, db_path: str) -> None:
         self.conn = sqlite3.connect(db_path)
         self.conn.row_factory = sqlite3.Row
-        cursor = self.conn.cursor()
-        cursor.execute(
-            """
-            CREATE TABLE IF NOT EXISTS cache (
-                id INTEGER PRIMARY KEY,
-                cache_key TEXT UNIQUE,
-                url TEXT,
-                method TEXT,
-                flow BLOB
+        try:
+            cursor = self.conn.cursor()
+            cursor.execute(
+                """
+                CREATE TABLE IF NOT EXISTS cache (
+                    id INTEGER PRIMARY KEY,
+                    cache_key TEXT UNIQUE,
+                    url TEXT,
+                    method TEXT,
+                    flow BLOB
+                )
+                """
             )
-            """
-        )
-        self.conn.commit()
+            self.conn.commit()
+        except Exception:
+            self.conn.close()
+            raise
 
     def get(self, cache_key: str) -> http.HTTPFlow | None:
         cursor = self.conn.cursor()

--- a/tests/storage/test_sqlite3.py
+++ b/tests/storage/test_sqlite3.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+from unittest.mock import MagicMock, patch
+
+import pytest
+
 from mitmcache.storage.sqlite3 import SQLiteStorage
 
 from ..example_flow import example_flow
@@ -18,6 +22,19 @@ def test_cache_storage() -> None:
     storage.purge("test")
     assert storage.get("test") is None
     storage.close()
+
+
+def test_sqlite_storage_closes_connection_on_init_failure() -> None:
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value.execute.side_effect = Exception(
+        "init failure"
+    )
+    with patch(
+        "mitmcache.storage.sqlite3.sqlite3.connect", return_value=mock_conn
+    ):
+        with pytest.raises(Exception, match="init failure"):
+            SQLiteStorage(":memory:")
+    mock_conn.close.assert_called_once()
 
 
 def test_cache_storage_keeps_request_metadata_order() -> None:


### PR DESCRIPTION
## Problem

`SQLiteStorage.__init__` opens a SQLite connection with `sqlite3.connect(db_path)`
but does not close it if the subsequent schema setup (`CREATE TABLE`) raises.

When the table creation fails (read-only filesystem, corrupted database, disk full,
etc.), `self.conn` is already open. Python's garbage collector will eventually
release the file lock, but until GC runs, the DB file remains locked — blocking
reconnection attempts or restarts in the same process.

## Change

Wrap the schema setup block in `try/except` with `self.conn.close()` in the
except handler before re-raising. This ensures the connection is always released
when `__init__` fails.

```python
try:
    cursor = self.conn.cursor()
    cursor.execute("CREATE TABLE IF NOT EXISTS cache ...")
    self.conn.commit()
except Exception:
    self.conn.close()
    raise
```

Also adds `test_sqlite_storage_closes_connection_on_init_failure` to verify
`conn.close()` is called when schema setup raises.

## Verification

- `pytest`: all 9 tests pass, including the new failure-path test
- `ruff check`: no new findings
