### PR TITLE
ci: enable uv cache in setup-uv steps

### DIFF
--- a/.github/workflows/octocov.yml
+++ b/.github/workflows/octocov.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Set up uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86 # v5
+        with:
+          enable-cache: true
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
## Summary

Add `enable-cache: true` to `astral-sh/setup-uv` steps in CI workflows. This makes the uv dependency cache explicit, avoiding cold-start dependency installs on every run.

## Change scope

- `.github/workflows/octocov.yml`: add `enable-cache: true` to the setup-uv step
- `.github/workflows/python-test.yml`: add `enable-cache: true` to the setup-uv step

## Verification

- `actionlint` passes on both modified workflows
- The `enable-cache: true` flag activates uv's built-in caching mechanism, keyed on `uv.lock` (which is present in the repo)

## Trade-offs

- Cache storage counts against the GitHub Actions cache quota (10 GB by default); negligible for a typical uv cache
- First run after a `uv.lock` change will be a cache miss; subsequent runs benefit