### PR TITLE
chore: add lefthook to run CI checks locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,34 @@ $ mitmdump -s inject.py --set cache_file=cache.db
 `uv run poe proxy` already passes `--set cache_file=cache.db` so it
 creates a `cache.db` file in the current directory automatically.
 
+## Development
+
+This repository uses [lefthook](https://lefthook.dev/) to run the same checks as CI
+locally, so problems surface before they reach CI.
+
+```sh
+# Install dependencies
+uv sync
+
+# Install the Git hooks (once; requires lefthook on your PATH)
+lefthook install
+```
+
+Once installed, the hooks run automatically:
+
+- **pre-commit**: `uv run poe check`
+- **pre-push**: `uv run poe check` and `uv run poe test`
+
+You can also run the checks manually:
+
+```sh
+uv run poe check
+uv run poe test
+```
+
+CI still runs the full matrix (see `.github/workflows/`); the hooks only bring that
+feedback earlier on your machine.
+
 # License
 
 MIT License

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,13 @@
+# Clear Git hook environment variables before running checks so nested or sibling
+# repositories are not affected: https://git-scm.com/docs/githooks
+pre-commit:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+
+pre-push:
+  jobs:
+    - name: check
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe check
+    - name: test
+      run: for name in $(env | sed -n 's/^\(GIT_[A-Za-z0-9_]*\)=.*/\1/p'); do unset "$name"; done; uv run poe test


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` so contributors can run the same checks as CI locally before pushing
- Hooks run `uv run poe check` on pre-commit and `uv run poe check` + `uv run poe test` on pre-push
- CI (GitHub Actions) is left completely unchanged — Actions remain the source of truth

## Changes

- `lefthook.yml`: defines `pre-commit` (check) and `pre-push` (check + test) hooks
- `README.md`: adds a `## Development` section documenting how to install and use the hooks

## Verification

- `uv run poe check` passes locally (ruff, all checks passed)
- `uv run poe test` passes locally (17 tests passed)
- Pre-commit hook fired and passed during `git commit`
- Pre-push hook fired and passed (both check and test) during `git push`

## Notes

- Requires `lefthook` on PATH to use the hooks (`lefthook install` is a one-time setup)
- No CI workflows were modified; GitHub Actions continue to run the full matrix as before
