### PR TITLE
fix: set fallback_version in setuptools_scm configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ package-dir = { "mitmcache" = "mitmcache" }
 write_to = "mitmcache/_version.py"
 version_scheme = "only-version"
 local_scheme = "no-local-version"
+fallback_version = "0.1.0"
 
 [build-system]
 requires = [


### PR DESCRIPTION
## Problem

This repository has no git tags. `setuptools_scm` derives the package version from git tags; without any tags, it silently falls back to the implicit default `"0.0"`. This means the installed package version is an opaque, non-descriptive string that carries no meaningful signal.

## Fix

Added `fallback_version = "0.1.0"` to the `[tool.setuptools_scm]` section in `pyproject.toml`:

```toml
[tool.setuptools_scm]
write_to = "mitmcache/_version.py"
version_scheme = "only-version"
local_scheme = "no-local-version"
fallback_version = "0.1.0"
```

This makes the fallback explicit and meaningful. When the first real git tag (e.g. `v0.1.0`) is created, `setuptools_scm` will automatically use the tag instead of this fallback — no further changes needed.

## Notes

- The package carries the `Private :: Do Not Upload` classifier and is not published to PyPI. The version is used for internal identification only.
- No behavioral change beyond the version string reported when no git tags are present.

## Changed Files

- `pyproject.toml`
