### PR TITLE
fix: align cache response-path condition for empty keys

### DIFF
--- a/mitmcache/cache.py
+++ b/mitmcache/cache.py
@@ -112,7 +112,7 @@ class Cache:
 
         # Check if the response has a cache key
         cache_key = self.get_cache_key_from_flow(flow)
-        if flow.metadata.get(self.cache_from_origin, False) and cache_key:
+        if flow.metadata.get(self.cache_from_origin, False) and cache_key is not None:
             self._store_response(cache_key, flow)
 
     def _store_response(self, cache_key: str, flow: http.HTTPFlow) -> None:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -148,6 +148,53 @@ def test_cache_hit() -> None:
         addon.done()
 
 
+def test_empty_cache_key_is_stored_and_hit() -> None:
+    """Empty cache key values should participate in request/response transitions."""
+    with taddons.context() as tctx:
+        addon = tctx.script("inject.py").addons[0]
+        storage = TrackingStorage(addon.storage)
+        addon.storage = storage
+
+        flow_store = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"")],
+            ),
+            resp=tutils.tresp(
+                content=b"Hello, World!",
+                status_code=200,
+            ),
+        )
+        addon.request(flow_store)
+        addon.response(flow_store)
+        assert storage.upsert_count == 1
+        assert storage.store_count == 0
+        assert storage.update_count == 0
+
+        flow_hit = tflow.tflow(
+            req=tutils.treq(
+                method=b"GET",
+                path=b"/",
+                host=b"localhost:65535",
+                headers=[(b"Mitm-Cache-Key", b"")],
+            ),
+            resp=False,
+        )
+        addon.request(flow_hit)
+        assert flow_hit.response is not None
+        assert flow_hit.response.text == "Hello, World!"
+        assert flow_hit.metadata[addon.cache_from_origin] is False
+        addon.response(flow_hit)
+
+        assert storage.upsert_count == 1
+        assert storage.store_count == 0
+        assert storage.update_count == 0
+
+        addon.done()
+
+
 def test_cache_entry_without_response_is_ignored() -> None:
     """Confirm that an incomplete cached flow does not short-circuit."""
     with taddons.context() as tctx:

--- a/uv.lock
+++ b/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-07-16T13:16:46.622404Z"
 exclude-newer-span = "P2D"
 
 [[package]]
@@ -274,14 +274,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/76/d4/81420972a676e8ffea40450d8c8c92943e7218a78fe9b64359836cc9876b/click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6", size = 338000, upload-time = "2026-06-24T17:45:15.148Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76", size = 119243, upload-time = "2026-06-24T17:45:13.73Z" },
 ]
 
 [[package]]
@@ -1156,11 +1156,11 @@ wheels = [
 
 [[package]]
 name = "setuptools"
-version = "82.0.0"
+version = "83.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/f3/748f4d6f65d1756b9ae577f329c951cda23fb900e4de9f70900ced962085/setuptools-82.0.0.tar.gz", hash = "sha256:22e0a2d69474c6ae4feb01951cb69d515ed23728cf96d05513d36e42b62b37cb", size = 1144893, upload-time = "2026-02-08T15:08:40.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/c6/76dc613121b793286a3f91621d7b75a2b493e0390ddca50f11993eadf192/setuptools-82.0.0-py3-none-any.whl", hash = "sha256:70b18734b607bd1da571d097d236cfcfacaf01de45717d59e6e04b96877532e0", size = 1003468, upload-time = "2026-02-08T15:08:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What changed
- Make response-side cache write gate use `cache_key is not None` to keep request/response state transitions consistent with cache key presence handling.
- Add regression test covering empty-cache-key request storing and subsequent cache hit.

## Validation
- uv run poe check
- uv run poe test
