### PR TITLE
Purge unreadable SQLite cache rows

### DIFF
--- a/mitmcache/storage/sqlite3.py
+++ b/mitmcache/storage/sqlite3.py
@@ -70,6 +70,7 @@ class SQLiteStorage:
             # Skip entries whose BLOB was written by a different mitmproxy
             # version; deserialization may silently fail or raise.
             if stored_version != _MITMPROXY_VERSION:
+                self._purge_with_cursor(cursor, cache_key)
                 return None
             cursor.execute(
                 "UPDATE cache SET last_accessed_at = ? WHERE cache_key = ?",
@@ -83,6 +84,7 @@ class SQLiteStorage:
                         None,
                     )
             except Exception:
+                self._purge_with_cursor(cursor, cache_key)
                 return None
 
         return None
@@ -194,6 +196,11 @@ class SQLiteStorage:
 
     def purge(self, cache_key: str) -> None:
         cursor = self.conn.cursor()
+        self._purge_with_cursor(cursor, cache_key)
+
+    def _purge_with_cursor(
+        self, cursor: sqlite3.Cursor, cache_key: str
+    ) -> None:
         cursor.execute("DELETE FROM cache WHERE cache_key=?", (cache_key,))
         self.conn.commit()
 

--- a/tests/storage/test_sqlite3.py
+++ b/tests/storage/test_sqlite3.py
@@ -156,8 +156,8 @@ def test_cache_storage_records_flow_format_version() -> None:
     storage.close()
 
 
-def test_cache_storage_version_mismatch_returns_none() -> None:
-    """Confirm that a version-mismatched entry is treated as a cache miss."""
+def test_cache_storage_version_mismatch_purges_unreadable_row() -> None:
+    """Version-mismatched entries should be removed after a failed read."""
     storage = SQLiteStorage(":memory:")
     flow = example_flow()
     storage.store("test", flow)
@@ -170,11 +170,16 @@ def test_cache_storage_version_mismatch_returns_none() -> None:
     storage.conn.commit()
 
     assert storage.get("test") is None
+    row = storage.conn.execute(
+        "SELECT 1 FROM cache WHERE cache_key=?",
+        ("test",),
+    ).fetchone()
+    assert row is None
     storage.close()
 
 
-def test_cache_storage_corrupt_blob_returns_none() -> None:
-    """Confirm that a corrupt BLOB does not crash get() and returns None."""
+def test_cache_storage_corrupt_blob_purges_unreadable_row() -> None:
+    """Corrupt BLOB rows should be removed after a failed read."""
     storage = SQLiteStorage(":memory:")
     flow = example_flow()
     storage.store("test", flow)
@@ -186,6 +191,11 @@ def test_cache_storage_corrupt_blob_returns_none() -> None:
     storage.conn.commit()
 
     assert storage.get("test") is None
+    row = storage.conn.execute(
+        "SELECT 1 FROM cache WHERE cache_key=?",
+        ("test",),
+    ).fetchone()
+    assert row is None
     storage.close()
 
 


### PR DESCRIPTION
## Summary
- purge SQLite cache rows when a cached flow cannot be read because the stored mitmproxy version no longer matches
- purge SQLite cache rows when flow deserialization fails on a corrupt BLOB
- extend the SQLite storage regression tests to verify unreadable rows are removed after the failed read path

## Testing
- `uv run poe check mitmcache/storage/sqlite3.py tests/storage/test_sqlite3.py`
- `uv run poe test tests/storage/test_sqlite3.py`
- `uv run poe check`
- `uv run poe test`

## Impact
Persistent cache files no longer keep unreadable rows in a permanent cache-miss state after a version mismatch or corrupt entry is observed once.
